### PR TITLE
js-react: update cheatsheet URL

### DIFF
--- a/_posts/2015-06-18-js.react.md
+++ b/_posts/2015-06-18-js.react.md
@@ -173,7 +173,7 @@
 
 
 ## Cheatsheets
-*   [React.js cheatsheet](http://ricostacruz.com/cheatsheets/react.html)
+*   [React.js cheatsheet](https://devhints.io/react)
 
 
 ## Курсы


### PR DESCRIPTION
http://ricostacruz.com/cheatsheets is now https://devhints.io :) (The old URL's are still accessible for now.)

See: https://devhints.io/react